### PR TITLE
Clean up how the recessive flag works

### DIFF
--- a/src/fingerprint.rs
+++ b/src/fingerprint.rs
@@ -263,7 +263,7 @@ pub fn remove_not_built_with(
         );
         lookup_from_names(rustup_toolchain_list.iter().map(|x| x.as_str()))?
     };
-    for fing in lookup_all_fingerprint_dirs(&dir.join("target")) {
+    for fing in lookup_all_fingerprint_dirs(dir) {
         let path = fing.into_path();
         let keep = load_all_fingerprints_built_with(&path, &hashed_rust_version_to_keep)?;
         total_disk_space +=
@@ -284,7 +284,7 @@ pub fn remove_older_then(
     debug!("cleaning: {:?} with remove_older_then", path);
     let mut total_disk_space = 0;
 
-    for fing in lookup_all_fingerprint_dirs(&path.join("target")) {
+    for fing in lookup_all_fingerprint_dirs(path) {
         let path = fing.into_path();
         let keep = load_all_fingerprints_newer_then(&path, &keep_duration)?;
         total_disk_space +=

--- a/src/fingerprint.rs
+++ b/src/fingerprint.rs
@@ -188,6 +188,10 @@ fn remove_not_built_with_in_a_profile(
     keep: &HashSet<String>,
     dry_run: bool,
 ) -> Result<u64, Error> {
+    debug!(
+        "cleaning: {:?} with remove_not_built_with_in_a_profile",
+        dir
+    );
     let mut total_disk_space = 0;
     total_disk_space += remove_not_matching_in_a_dir(&dir.join(".fingerprint"), &keep, dry_run)?;
     total_disk_space += remove_not_matching_in_a_dir(&dir.join("build"), &keep, dry_run)?;
@@ -243,6 +247,7 @@ pub fn remove_not_built_with(
     rust_vertion_to_keep: Option<&str>,
     dry_run: bool,
 ) -> Result<u64, Error> {
+    debug!("cleaning: {:?} with remove_not_built_with", dir);
     let mut total_disk_space = 0;
     let hashed_rust_version_to_keep = if let Some(names) = rust_vertion_to_keep {
         info!(
@@ -276,6 +281,7 @@ pub fn remove_older_then(
     keep_duration: &Duration,
     dry_run: bool,
 ) -> Result<u64, Error> {
+    debug!("cleaning: {:?} with remove_older_then", path);
     let mut total_disk_space = 0;
 
     for fing in lookup_all_fingerprint_dirs(&path.join("target")) {

--- a/src/fingerprint.rs
+++ b/src/fingerprint.rs
@@ -208,7 +208,12 @@ fn lookup_all_fingerprint_dirs(dir: &Path) -> impl Iterator<Item = DirEntry> {
         .min_depth(1)
         .into_iter()
         .filter_map(|entry| entry.ok())
-        .filter(|p| &p.file_name().to_string_lossy() == ".fingerprint")
+        .filter(|e| {
+            e.file_name()
+                .to_str()
+                .map(|s| s == ".fingerprint")
+                .unwrap_or(false)
+        })
 }
 
 fn lookup_from_names<'a>(iter: impl Iterator<Item = &'a str>) -> Result<HashSet<u64>, Error> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,13 +63,9 @@ fn setup_logging(verbose: bool) {
         .unwrap();
 }
 
-/// Returns whether the given path points to a valid Cargo project.
+/// Returns whether the given path to a Cargo.toml points to a real target directory.
 fn is_cargo_root(path: &Path) -> bool {
-    let mut path = path.to_path_buf();
-
-    // Check that cargo.toml exists.
-    path.push("Cargo.toml");
-    if let Ok(metadata) = cargo_metadata::metadata(Some(path.as_path())) {
+    if let Ok(metadata) = cargo_metadata::metadata(Some(path)) {
         Path::new(&metadata.target_directory).exists()
     } else {
         false
@@ -84,11 +80,10 @@ fn find_cargo_projects(root: &Path) -> Vec<PathBuf> {
         .min_depth(1)
         .into_iter()
         .filter_map(|e| e.ok())
+        .filter(|f| f.file_name() == "Cargo.toml")
     {
-        if let Ok(metadata) = entry.metadata() {
-            if metadata.is_dir() && is_cargo_root(entry.path()) {
-                project_paths.push(entry.path().to_path_buf());
-            }
+        if is_cargo_root(entry.path()) {
+            project_paths.push(entry.path().parent().to_path_buf());
         }
     }
     project_paths

--- a/src/main.rs
+++ b/src/main.rs
@@ -195,8 +195,17 @@ fn main() {
 
         let paths = if matches.is_present("recursive") {
             find_cargo_projects(&path)
+        } else if let Ok(metadata) = cargo_metadata::metadata(None) {
+            let out = Path::new(&metadata.target_directory).to_path_buf();
+            if out.exists() {
+                vec![out]
+            } else {
+                error!("Failed to clean {:?} as it does not exist.", out);
+                return;
+            }
         } else {
-            vec![path.join("target")]
+            error!("Failed to clean {:?} as it is not a cargo project.", path);
+            return;
         };
 
         if matches.is_present("installed") || matches.is_present("toolchains") {


### PR DESCRIPTION
This ended up being a big PR, but each commit is small and focused. The goal of this was to get `cargo sweep -i -r` to work on my documents folder.

Some things that needed to be fixed for my projects:
- Some cargo project specify a different name for the `target` dir.
- Some even use a shared folder several levels up from where the `Cargo.toml` is.
- Some, maybe just Cargo itself, have full projects in the target dir for testing.
- There are a lot of files in `.git` folder that do not need to be searched.

with this `cargo sweep -i -r` on my documents is fast and reliable enough to add to my `rustup update` script.