### PR TITLE
it is called cargo-sweep not hello

### DIFF
--- a/ci/before_deploy.ps1
+++ b/ci/before_deploy.ps1
@@ -11,7 +11,7 @@ Set-Location $STAGE
 $ZIP = "$SRC_DIR\$($Env:CRATE_NAME)-$($Env:APPVEYOR_REPO_TAG_NAME)-$($Env:TARGET).zip"
 
 # TODO Update this to package the right artifacts
-Copy-Item "$SRC_DIR\target\$($Env:TARGET)\release\hello.exe" '.\'
+Copy-Item "$SRC_DIR\target\$($Env:TARGET)\release\cargo-sweep.exe" '.\'
 
 7z a "$ZIP" *
 

--- a/ci/before_deploy.sh
+++ b/ci/before_deploy.sh
@@ -18,10 +18,10 @@ main() {
     test -f Cargo.lock || cargo generate-lockfile
 
     # TODO Update this to build the artifacts that matter to you
-    cross rustc --bin hello --target $TARGET --release -- -C lto
+    cross rustc --bin cargo-sweep --target $TARGET --release -- -C lto
 
     # TODO Update this to package the right artifacts
-    cp target/$TARGET/release/hello $stage/
+    cp target/$TARGET/release/cargo-sweep $stage/
 
     cd $stage
     tar czf $src/$CRATE_NAME-$TRAVIS_TAG-$TARGET.tar.gz *

--- a/test.bat
+++ b/test.bat
@@ -1,0 +1,8 @@
+cargo clean
+cargo +nightly build
+cargo +stable build
+cargo sweep -s
+cargo +stable build
+cargo sweep -f
+cargo +stable build
+cargo +nightly build

--- a/test2.bat
+++ b/test2.bat
@@ -1,0 +1,12 @@
+set RUSTC=C:\Users\finkelman.SEMCOGDOM\.rustup\toolchains\nightly-x86_64-pc-windows-msvc\bin\rustc.exe
+"C:\Users\finkelman.SEMCOGDOM\Documents\MyProjects\cargo\target\debug\cargo.exe" build
+set RUSTC=C:\Users\finkelman.SEMCOGDOM\.rustup\toolchains\stable-x86_64-pc-windows-msvc\bin\rustc.exe
+"C:\Users\finkelman.SEMCOGDOM\Documents\MyProjects\cargo\target\debug\cargo.exe" build
+"C:\Users\finkelman.SEMCOGDOM\Documents\MyProjects\cargo\target\debug\cargo.exe" sweep -s
+set RUSTC=C:\Users\finkelman.SEMCOGDOM\.rustup\toolchains\stable-x86_64-pc-windows-msvc\bin\rustc.exe
+"C:\Users\finkelman.SEMCOGDOM\Documents\MyProjects\cargo\target\debug\cargo.exe" build
+"C:\Users\finkelman.SEMCOGDOM\Documents\MyProjects\cargo\target\debug\cargo.exe" sweep -f
+set RUSTC=C:\Users\finkelman.SEMCOGDOM\.rustup\toolchains\stable-x86_64-pc-windows-msvc\bin\rustc.exe
+"C:\Users\finkelman.SEMCOGDOM\Documents\MyProjects\cargo\target\debug\cargo.exe" build
+set RUSTC=C:\Users\finkelman.SEMCOGDOM\.rustup\toolchains\nightly-x86_64-pc-windows-msvc\bin\rustc.exe
+"C:\Users\finkelman.SEMCOGDOM\Documents\MyProjects\cargo\target\debug\cargo.exe" build


### PR DESCRIPTION
I don't know if this is sufficient to make the next release easily installable, but I think it is a step in the correct direction. cc https://github.com/holmgr/cargo-sweep/issues/4#issuecomment-449103569, I think when this is working it will be possible to install without building from scratch with something like [this](https://github.com/japaric/trust#use-the-binary-releases-on-travis-ci). I can confirm that 0.3.0 does not support it, but I do not know if this is enough to get it working.

@epage any other advice for getting this set up or for testing that it is working correctly?