### PR TITLE
the tags we are making do not start with v

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ before_cache:
 - chmod -R a+r $HOME/.cargo
 branches:
   only:
-  - "/^v\\d+\\.\\d+\\.\\d+.*$/"
+  - "/^v?\\d+\\.\\d+\\.\\d+.*$/"
   - master
 notifications:
   email:


### PR DESCRIPTION
This was suggested on gitter.im/rust-lang/WG-CLI by @epage. This is another try to get eazy installing working, cc https://github.com/holmgr/cargo-sweep/pull/18. This should mean that future releases like you have made in the past will get picked up.

It is possible that adding a tag "v0.4.0" to the commit that is currently tagged "0.4.0" will get this working, or we could just release a "0.4.1" after this is merged, or we can wheate for the next feature to be added.