### PR TITLE
Don't display too many decimal places in format_bytes

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -4,7 +4,7 @@ pub fn format_bytes(bytes: u64) -> String {
     let mut bytes = bytes as f64;
     for prefix in prefixes.iter() {
         if bytes < 1024. {
-            return format!("{} {}", bytes, prefix);
+            return format!("{.2} {}", bytes, prefix);
         }
         bytes /= 1024.;
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -4,7 +4,7 @@ pub fn format_bytes(bytes: u64) -> String {
     let mut bytes = bytes as f64;
     for prefix in prefixes.iter() {
         if bytes < 1024. {
-            return format!("{.2} {}", bytes, prefix);
+            return format!("{:.2} {}", bytes, prefix);
         }
         bytes /= 1024.;
     }


### PR DESCRIPTION
Thanks for this tool.  It's really handy!

On first running it, I saw:

```
[INFO] Cleaned 859.8648061752319 MiB
```

which doesn't make a ton of sense because it talks about fractions of a byte.

Two decimal places seems like enough for a human-readable value like this.