### PR TITLE
Make default output less noisy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,10 +100,12 @@ dependencies = [
  "log",
  "predicates",
  "pretty_assertions",
+ "regex",
  "serde",
  "serde_derive",
  "serde_json",
  "tempfile",
+ "unindent",
  "walkdir",
  "which",
 ]
@@ -545,9 +547,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
+checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -750,6 +752,12 @@ name = "unicode-width"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7007dbd421b92cc6e28410fe7362e2e0a2503394908f417b68ec8d1c364c4e20"
+
+[[package]]
+name = "unindent"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1766d682d402817b5ac4490b3c3002d91dfa0d22812f341609f97b08757359c"
 
 [[package]]
 name = "vec_map"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,5 @@ predicates = "2.1.1"
 tempfile = "3.3.0"
 which = { version = "4.3.0", default-features = false }
 pretty_assertions = "1.3"
+regex = "1.7.0"
+unindent = "0.1.11"

--- a/src/fingerprint.rs
+++ b/src/fingerprint.rs
@@ -215,21 +215,21 @@ fn remove_not_matching_in_a_dir(
                     total_disk_space += metadata.len();
                     if !dry_run {
                         match remove_file(&path) {
-                            Ok(_) => info!("Successfully removed: {:?}", &path),
+                            Ok(_) => debug!("Successfully removed: {:?}", &path),
                             Err(e) => warn!("Failed to remove: {:?} {}", &path, e),
                         };
                     } else {
-                        info!("Would remove: {:?}", &path);
+                        debug!("Would remove: {:?}", &path);
                     }
                 } else if path.is_dir() {
                     total_disk_space += total_disk_space_dir(&path);
                     if !dry_run {
                         match remove_dir_all(&path) {
-                            Ok(_) => info!("Successfully removed: {:?}", &path),
+                            Ok(_) => debug!("Successfully removed: {:?}", &path),
                             Err(e) => warn!("Failed to remove: {:?} {}", &path, e),
                         };
                     } else {
-                        info!("Would remove: {:?}", &path);
+                        debug!("Would remove: {:?}", &path);
                     }
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -251,9 +251,15 @@ fn main() -> anyhow::Result<()> {
             for project_path in &paths {
                 match remove_not_built_with(project_path, matches.value_of("toolchains"), dry_run) {
                     Ok(cleaned_amount) if dry_run => {
-                        info!("Would clean: {}", format_bytes(cleaned_amount))
+                        info!(
+                            "Would clean: {} from {project_path:?}",
+                            format_bytes(cleaned_amount)
+                        )
                     }
-                    Ok(cleaned_amount) => info!("Cleaned {}", format_bytes(cleaned_amount)),
+                    Ok(cleaned_amount) => info!(
+                        "Cleaned {} from {project_path:?}",
+                        format_bytes(cleaned_amount)
+                    ),
                     Err(e) => error!(
                         "{:?}",
                         e.context(format!("Failed to clean {project_path:?}"))
@@ -275,9 +281,15 @@ fn main() -> anyhow::Result<()> {
             for project_path in &paths {
                 match remove_older_until_fits(project_path, size, dry_run) {
                     Ok(cleaned_amount) if dry_run => {
-                        info!("Would clean: {}", format_bytes(cleaned_amount))
+                        info!(
+                            "Would clean: {} from {project_path:?}",
+                            format_bytes(cleaned_amount)
+                        )
                     }
-                    Ok(cleaned_amount) => info!("Cleaned {}", format_bytes(cleaned_amount)),
+                    Ok(cleaned_amount) => info!(
+                        "Cleaned {} from {project_path:?}",
+                        format_bytes(cleaned_amount)
+                    ),
                     Err(e) => error!("Failed to clean {:?}: {:?}", project_path, e),
                 };
             }
@@ -297,9 +309,15 @@ fn main() -> anyhow::Result<()> {
             for project_path in &paths {
                 match remove_older_than(project_path, &keep_duration, dry_run) {
                     Ok(cleaned_amount) if dry_run => {
-                        info!("Would clean: {}", format_bytes(cleaned_amount))
+                        info!(
+                            "Would clean: {} from {project_path:?}",
+                            format_bytes(cleaned_amount)
+                        )
                     }
-                    Ok(cleaned_amount) => info!("Cleaned {}", format_bytes(cleaned_amount)),
+                    Ok(cleaned_amount) => info!(
+                        "Cleaned {} from {project_path:?}",
+                        format_bytes(cleaned_amount)
+                    ),
                     Err(e) => error!("Failed to clean {:?}: {:?}", project_path, e),
                 };
             }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -123,7 +123,7 @@ fn count_cleaned(target: &TempDir, args: &[&str], old_size: u64) -> Result<u64> 
     let one_percent = old_size as f64 * 0.01;
     assert!(
         diff <= one_percent as u64,
-        "new_size={new_size}, old_size={old_size}, cleaned={cleaned}, diff={diff}, 1%={one_percent}"
+        "new_size={new_size}, old_size={old_size}, cleaned={cleaned}, diff={diff}, 1%={one_percent}",
     );
 
     Ok(cleaned)

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -49,6 +49,7 @@ fn sweep(args: &[&str]) -> Command {
     let mut cmd = Command::new(cargo_bin("cargo-sweep"));
     cmd.arg("sweep")
         .current_dir(project_dir("sample-project"))
+        .arg("--verbose")
         .args(args);
     cmd
 }
@@ -158,7 +159,7 @@ fn stamp_file() -> TestResult {
     let (size, target) = build("sample-project")?;
 
     // Create a stamp file for --file.
-    let assert = run(sweep(&["--stamp", "-v"]));
+    let assert = run(sweep(&["--stamp"]));
     println!(
         "{}",
         std::str::from_utf8(&assert.get_output().stdout).unwrap()

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -88,13 +88,21 @@ fn clean_and_parse(target: &TempDir, args: &[&str]) -> Result<u64> {
 
     let output = assertion.get_output();
     assert!(output.stderr.is_empty());
+
+    // Extract the size from the last line of stdout, example:
+    // - stdout: "[INFO] Would clean: 9.43 KiB from "/home/user/project/target"
+    // - extracted amount: "9.43 KiB "
     let amount = std::str::from_utf8(&output.stdout)?
         .lines()
         .last()
         .unwrap()
         .split(clean_msg)
         .nth(1)
-        .unwrap();
+        .unwrap()
+        .split_inclusive(' ')
+        .take(2)
+        .collect::<String>();
+
     let cleaned = amount
         .parse::<human_size::Size>()
         .context(format!("failed to parse amount {amount}"))?

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -213,18 +213,18 @@ fn empty_project_output() -> TestResult {
     let pattern = unindent(
         r#"\[DEBUG\] cleaning: ".+" with remove_older_until_fits
         \[DEBUG\] size_to_remove: .+
-        \[DEBUG\] Sizing: ".+/debug" with total_disk_space_in_a_profile
+        \[DEBUG\] Sizing: ".+debug" with total_disk_space_in_a_profile
         \[DEBUG\] Hashs by time: \[
             \(
                 .+,
                 ".+",
             \),
         \]
-        \[DEBUG\] cleaning: ".+/debug" with remove_not_built_with_in_a_profile
-        \[DEBUG\] Successfully removed: ".+/debug/deps/libsample_project-.+\.rlib"
-        \[DEBUG\] Successfully removed: ".+/debug/deps/libsample_project-.+\.rmeta"
-        \[DEBUG\] Successfully removed: ".+/debug/deps/sample_project-.+\.d"
-        \[DEBUG\] Successfully removed: ".+/debug/.fingerprint/sample-project-.+"
+        \[DEBUG\] cleaning: ".+debug" with remove_not_built_with_in_a_profile
+        \[DEBUG\] Successfully removed: ".+libsample_project-.+\.rlib"
+        \[DEBUG\] Successfully removed: ".+libsample_project-.+\.rmeta"
+        \[DEBUG\] Successfully removed: ".+sample_project-.+\.d"
+        \[DEBUG\] Successfully removed: ".+.fingerprint.+sample-project-.+"
         \[INFO\] Cleaned .+ from ".+""#,
     );
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -210,25 +210,23 @@ fn empty_project_output() -> TestResult {
 
     let output = std::str::from_utf8(&assert.get_output().stdout).unwrap();
 
-    let regex_skip = r#".+?"#;
-
-    let pattern = unindent(&format!(
-        r#"\[DEBUG\] cleaning: "/tmp/{regex_skip}" with remove_older_until_fits
-        \[DEBUG\] size_to_remove: {regex_skip}
-        \[DEBUG\] Sizing: "/tmp/{regex_skip}/debug" with total_disk_space_in_a_profile
+    let pattern = unindent(
+        r#"\[DEBUG\] cleaning: ".+" with remove_older_until_fits
+        \[DEBUG\] size_to_remove: .+
+        \[DEBUG\] Sizing: ".+/debug" with total_disk_space_in_a_profile
         \[DEBUG\] Hashs by time: \[
             \(
-                {regex_skip},
-                "{regex_skip}",
+                .+,
+                ".+",
             \),
         \]
-        \[DEBUG\] cleaning: "/tmp/{regex_skip}/debug" with remove_not_built_with_in_a_profile
-        \[DEBUG\] Successfully removed: "/tmp/{regex_skip}/debug/deps/libsample_project-{regex_skip}.rlib"
-        \[DEBUG\] Successfully removed: "/tmp/{regex_skip}/debug/deps/libsample_project-{regex_skip}.rmeta"
-        \[DEBUG\] Successfully removed: "/tmp/{regex_skip}/debug/deps/sample_project-{regex_skip}.d"
-        \[DEBUG\] Successfully removed: "/tmp/{regex_skip}/debug/.fingerprint/sample-project-{regex_skip}"
-        \[INFO\] Cleaned {regex_skip} from "/tmp/{regex_skip}""#,
-    ));
+        \[DEBUG\] cleaning: ".+/debug" with remove_not_built_with_in_a_profile
+        \[DEBUG\] Successfully removed: ".+/debug/deps/libsample_project-.+\.rlib"
+        \[DEBUG\] Successfully removed: ".+/debug/deps/libsample_project-.+\.rmeta"
+        \[DEBUG\] Successfully removed: ".+/debug/deps/sample_project-.+\.d"
+        \[DEBUG\] Successfully removed: ".+/debug/.fingerprint/sample-project-.+"
+        \[INFO\] Cleaned .+ from ".+""#,
+    );
 
     assert!(
         regex_matches(&pattern, output),


### PR DESCRIPTION
Fixes #74.

`cargo-sweep` logs every deleted file, this makes the output
very noisy and hard to follow (outputs approximately a thousand
lines per cleaned project).

This PR changes the default output to omit deleted files, and
only show them with the `--verbose` flag.
