### PR TITLE
Tell the user when `--recursive` is traversing folders

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -149,6 +149,7 @@ fn main() -> anyhow::Result<()> {
     };
 
     let processed_paths = if args.recursive {
+        info!("Searching recursively for Rust project folders");
         paths
             .iter()
             .flat_map(|path| find_cargo_projects(path, args.hidden))

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -589,10 +589,14 @@ fn check_toolchain_listing_on_multiple_projects() -> TestResult {
         .filter(|line| line.starts_with("[INFO]"))
         .collect::<Vec<_>>();
 
-    assert_eq!(lines.len(), 3);
-    assert!(lines[0].starts_with("[INFO] Using all installed toolchains:"));
-    assert!(lines[1].starts_with("[INFO] Would clean:"));
+    assert_eq!(lines.len(), 4);
+    assert_eq!(
+        lines[0].trim(),
+        "[INFO] Searching recursively for Rust project folders"
+    );
+    assert!(lines[1].starts_with("[INFO] Using all installed toolchains:"));
     assert!(lines[2].starts_with("[INFO] Would clean:"));
+    assert!(lines[3].starts_with("[INFO] Would clean:"));
 
     Ok(())
 }


### PR DESCRIPTION
After calling `cargo-sweep` with `--recursive` in a big folder, the tool usually stays silent for a long time leaving the user wondering what's going on

To solve that, I added a log that tells that `cargo-sweep` is traversing recursively directories, that's why it's taking long