### PR TITLE
Don't panic when timestamp file is not found

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -234,8 +234,7 @@ fn main() -> anyhow::Result<()> {
         }
     } else {
         let keep_duration = if let Criterion::File = criterion {
-            let ts = Timestamp::load(paths[0].as_path(), dry_run)
-                .expect("Failed to load timestamp file");
+            let ts = Timestamp::load(paths[0].as_path(), dry_run)?;
             Duration::from(ts)
         } else if let Criterion::Time(days_to_keep) = criterion {
             Duration::from_secs(days_to_keep * 24 * 3600)

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -323,6 +323,17 @@ fn error_status() -> TestResult {
     Ok(())
 }
 
+/// This scenario used to panic: https://github.com/holmgr/cargo-sweep/issues/117
+#[test]
+fn stamp_file_not_found() -> TestResult {
+    sweep(&["--file"])
+        .current_dir(test_dir().join("sample-project"))
+        .assert()
+        .failure()
+        .stderr(contains("failed to read stamp file").and(contains("panicked").not()));
+    Ok(())
+}
+
 #[test]
 fn path() -> TestResult {
     let (_, target) = build("sample-project")?;


### PR DESCRIPTION
Fixes #117.

The new output:

```
Error: failed to read stamp file /home/dima/code/oss/cargo-sweep/sweep.timestamp

Caused by:
    No such file or directory (os error 2)
```