### PR TITLE
Print "Cleaned nothing" instead of "Cleaned 0.00 B"

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,7 @@ use self::fingerprint::{
     hash_toolchains, remove_not_built_with, remove_older_than, remove_older_until_fits,
 };
 use self::stamp::Timestamp;
-use self::util::format_bytes;
+use self::util::{format_bytes, format_bytes_or_nothing};
 
 /// Setup logging according to verbose flag.
 fn setup_logging(verbosity_level: u8) {
@@ -195,14 +195,14 @@ fn main() -> anyhow::Result<()> {
                 Ok(cleaned_amount) if dry_run => {
                     info!(
                         "Would clean: {} from {project_path:?}",
-                        format_bytes(cleaned_amount)
+                        format_bytes_or_nothing(cleaned_amount)
                     );
                     total_cleaned += cleaned_amount;
                 }
                 Ok(cleaned_amount) => {
                     info!(
                         "Cleaned {} from {project_path:?}",
-                        format_bytes(cleaned_amount)
+                        format_bytes_or_nothing(cleaned_amount)
                     );
                     total_cleaned += cleaned_amount;
                 }
@@ -218,14 +218,14 @@ fn main() -> anyhow::Result<()> {
                 Ok(cleaned_amount) if dry_run => {
                     info!(
                         "Would clean: {} from {project_path:?}",
-                        format_bytes(cleaned_amount)
+                        format_bytes_or_nothing(cleaned_amount)
                     );
                     total_cleaned += cleaned_amount;
                 }
                 Ok(cleaned_amount) => {
                     info!(
                         "Cleaned {} from {project_path:?}",
-                        format_bytes(cleaned_amount)
+                        format_bytes_or_nothing(cleaned_amount)
                     );
                     total_cleaned += cleaned_amount;
                 }
@@ -248,14 +248,14 @@ fn main() -> anyhow::Result<()> {
                 Ok(cleaned_amount) if dry_run => {
                     info!(
                         "Would clean: {} from {project_path:?}",
-                        format_bytes(cleaned_amount)
+                        format_bytes_or_nothing(cleaned_amount)
                     );
                     total_cleaned += cleaned_amount;
                 }
                 Ok(cleaned_amount) => {
                     info!(
                         "Cleaned {} from {project_path:?}",
-                        format_bytes(cleaned_amount)
+                        format_bytes_or_nothing(cleaned_amount)
                     );
                     total_cleaned += cleaned_amount;
                 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -11,6 +11,16 @@ pub fn format_bytes(bytes: u64) -> String {
     format!("{bytes} TiB")
 }
 
+/// Like [format_bytes], but with a special case for formatting `0` as `"nothing"`.
+/// With `--recursive`, this helps visually distinguish folders without outdated artifacts.
+/// See [#93](https://github.com/holmgr/cargo-sweep/issues/93).
+pub fn format_bytes_or_nothing(bytes: u64) -> String {
+    match bytes {
+        0 => "nothing".to_string(),
+        _ => format_bytes(bytes),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -38,6 +48,19 @@ mod tests {
         assert_eq!(
             "1.00 TiB".parse::<human_size::Size>().unwrap().to_bytes(),
             1024 * 1024 * 1024 * 1024
+        );
+    }
+
+    #[test]
+    fn test_format_bytes_or_nothing() {
+        assert_eq!(format_bytes_or_nothing(0), "nothing");
+
+        // Copy-pasted some non-zero values from `format_bytes` tests to test that the output is identical.
+        assert_eq!(format_bytes(1024), format_bytes_or_nothing(1024));
+        assert_eq!(format_bytes(1023), format_bytes_or_nothing(1023));
+        assert_eq!(
+            format_bytes(500 * 1024 * 1024),
+            format_bytes_or_nothing(500 * 1024 * 1024)
         );
     }
 }


### PR DESCRIPTION
Implement #93. I liked "Cleaned nothing from" variant and chose that.

Example output from that issue now looks like this:

```
[INFO] Cleaned nothing from "/home/marcospb19/cargo-sweep/target"
[INFO] Cleaned nothing from "/home/marcospb19/code/rust/target"
[INFO] Cleaned nothing from "/home/marcospb19/ds/client/target"
[INFO] Cleaned nothing from "/home/marcospb19/ds/file-backed-queue/target"
[INFO] Cleaned nothing from "/home/marcospb19/ds/gui/target"
[INFO] Cleaned nothing from "/home/marcospb19/ds/proto/target"
[INFO] Cleaned nothing from "/home/marcospb19/ds/recording-datatypes/target"
[INFO] Cleaned nothing from "/home/marcospb19/ds/scoring/target"
[INFO] Cleaned nothing from "/home/marcospb19/ds/server/target"
[INFO] Cleaned nothing from "/home/marcospb19/ds/server-store/target"
[INFO] Cleaned nothing from "/home/marcospb19/languages/cacau/target"
[INFO] Cleaned 70.13 KiB from "/home/marcospb19/languages/cocoa/target"
[INFO] Cleaned nothing from "/home/marcospb19/languages/dada/target"
[INFO] Cleaned nothing from "/home/marcospb19/languages/lalrpop/target"
[INFO] Cleaned nothing from "/home/marcospb19/languages/lox/target"
[INFO] Cleaned nothing from "/home/marcospb19/languages/rustfmt/target"
[INFO] Cleaned nothing from "/home/marcospb19/languages/sushi/target"
[INFO] Cleaned nothing from "/home/marcospb19/ouch/target"
[INFO] Cleaned nothing from "/home/marcospb19/ouch/target/package/ouch-0.4.0/target"
[INFO] Cleaned nothing from "/home/marcospb19/rust-skeleton-hexagonal/target"
[INFO] Cleaned 23.63 KiB from "/home/marcospb19/stuff/dotao/target"
[INFO] Cleaned 23.88 KiB from "/home/marcospb19/stuff/fs-tree/target"
[INFO] Cleaned 6.48 GiB from "/home/marcospb19/stuff/keyrocky/target"
[INFO] Cleaned nothing from "/home/marcospb19/stuff/reflect/target"
[INFO] Cleaned 3.04 KiB from "/home/marcospb19/stuff/wsid/target"
```

I think, it's pretty nice. Uniform and easy to skim at the same time.